### PR TITLE
feat: add some optional keys to contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ console.log(`Authorization access to contacts is: ${authStatus}`)
 */
 ```
 
-### contacts.getAllContacts()
+### contacts.getAllContacts([extraProperties])
+
+* `extraProperties` string[] (optional) - an array of extra contact properties to fetch that can be any of: `jobTitle`, `departmentName`, `organizationName`, `middleName`, `note`, `contactImage`, or `contactThumbnailImage`.
 
 Returns `Array<Object>` - Returns an array of contact objects.
 
@@ -59,7 +61,13 @@ The returned objects will take the following format:
 * `phoneNumbers` String[] - An array of phone numbers as strings in [E.164 format](https://en.wikipedia.org/wiki/E.164).
 * `emailAddresses` String[] - An array of email addresses as strings.
 * `postalAddresses` String[] - An array of postal as strings.
-* `contactImage` Buffer (optional) - a Buffer representation of the contact's image, if one has been set.
+* `jobTitle` String (optional) - The contact's job title.
+* `departmentName` String (optional) - The name of the department associated with the contact.
+* `organizationName`  String (optional) - The name of the organization associated with the contact.
+* `middleName` String (optional) - The contact's middle name.
+* `note` String (optional) - The note associated with the contact.
+* `contactImage` Buffer (optional) - a Buffer representation of the contact's profile picture.
+* `contactThumbnailImage` Buffer (optional) - a Buffer representation of The thumbnail version of the contact’s profile picture.
 
 This method will return an empty array (`[]`) if access to Contacts has not been granted.
 
@@ -77,17 +85,16 @@ console.log(allContacts[0])
     nickname: 'Johnny',
     birthday: '1970-01-01',
     phoneNumbers: [ +11234566789' ],
-    emailAddresses: [ 'johnny@appleseed.com' ] 
-    postalAddresses: [ '123 Pine Tree Way\nBlack Oak, Arkansas 72414\nUnited States' ],
-    contactImage: <Buffer ff d8 ff e0 00 10 4a 46 49 46 00 01 01 00 00 48 00 48 00 00 ff e1 00 4c 45 78 69 66 00 00 4d 4d 00 2a 00 00 00 08 00 01 87 69 00 04 00 00 00 01 00 00 ... 139493 more bytes>
+    emailAddresses: [ 'johnny@appleseed.com' ],
+    postalAddresses: [ '123 Pine Tree Way\nBlack Oak, Arkansas 72414\nUnited States' ]
   }
 ]
 */
 ```
 
-### contacts.getContactsByName(name)
+### contacts.getContactsByName(name[, extraProperties])
 
-* `name` String (required) - The first, last, or full name of a contact.
+* `extraProperties` string[] (optional) - an array of extra contact properties to fetch that can be any of: `jobTitle`, `departmentName`, `organizationName`, `middleName`, `note`, `contactImage`, or `contactThumbnailImage`.
 
 Returns `Array<Object>` - Returns an array of contact objects where either the first or last name of the contact matches `name`.
 
@@ -102,7 +109,13 @@ The returned object will take the following format:
 * `phoneNumbers` String[] - An array of phone numbers as strings in [E.164 format](https://en.wikipedia.org/wiki/E.164).
 * `emailAddresses` String[] - An array of email addresses as strings.
 * `postalAddresses` String[] - An array of postal as strings.
-* `contactImage` Buffer (optional) - a Buffer representation of the contact's image, if one has been set.
+* `jobTitle` String (optional) - The contact's job title.
+* `departmentName` String (optional) - The name of the department associated with the contact.
+* `organizationName`  String (optional) - The name of the organization associated with the contact.
+* `middleName` String (optional) - The contact's middle name.
+* `note` String (optional) - The note associated with the contact.
+* `contactImage` Buffer (optional) - a Buffer representation of the contact's profile picture.
+* `contactThumbnailImage` Buffer (optional) - a Buffer representation of The thumbnail version of the contact’s profile picture.
 
 This method will return an empty array (`[]`) if access to Contacts has not been granted.
 
@@ -120,9 +133,8 @@ console.log(contacts)
     nickname: 'Johnny',
     birthday: '1970-01-01',
     phoneNumbers: [ +11234566789' ],
-    emailAddresses: [ 'johnny@appleseed.com' ] 
+    emailAddresses: [ 'johnny@appleseed.com' ],
     postalAddresses: [ '123 Pine Tree Way\nBlack Oak, Arkansas 72414\nUnited States' ]
-    contactImage: <Buffer ff d8 ff e0 00 10 4a 46 49 46 00 01 01 00 00 48 00 48 00 00 ff e1 00 4c 45 78 69 66 00 00 4d 4d 00 2a 00 00 00 08 00 01 87 69 00 04 00 00 00 01 00 00 ... 139493 more bytes>
   }
 ]
 */

--- a/index.js
+++ b/index.js
@@ -1,9 +1,23 @@
 const contacts = require('bindings')('contacts.node')
 
-function getContactsByName(name) {
-  if (typeof name !== 'string') throw new TypeError('name must be a string')
+function getAllContacts(extraProperties = []) {
+  if (extraProperties.constructor.name !== 'Array') {
+    throw new TypeError('extraProperties must be an array')
+  }
 
-  return contacts.getContactsByName.call(this, name)
+  return contacts.getAllContacts.call(this, extraProperties)
+}
+
+function getContactsByName(name, extraProperties = []) {
+  if (typeof name !== 'string') {
+    throw new TypeError('name must be a string')
+  }
+
+  if (Array.isArray(extraProperties)) {
+    throw new TypeError('extraProperties must be an array')
+  }
+
+  return contacts.getContactsByName.call(this, name, extraProperties)
 }
 
 function addNewContact(contact) {
@@ -17,16 +31,25 @@ function addNewContact(contact) {
     const hasPhoneNumbers = contact.hasOwnProperty('phoneNumbers')
     const hasEmailAddresses = contact.hasOwnProperty('emailAddresses')
 
-    if (hasFirstName && typeof contact.firstName !== 'string')
+    if (hasFirstName && typeof contact.firstName !== 'string') {
       throw new TypeError('firstName must be a string')
-    if (hasLastName && typeof contact.lastName !== 'string')
+    }
+
+    if (hasLastName && typeof contact.lastName !== 'string') {
       throw new TypeError('lastName must be a string')
-    if (hasNickname && typeof contact.nickname !== 'string')
+    }
+
+    if (hasNickname && typeof contact.nickname !== 'string') {
       throw new TypeError('nickname must be a string')
-    if (hasPhoneNumbers && !Array.isArray(contact.phoneNumbers))
+    }
+
+    if (hasPhoneNumbers && !Array.isArray(contact.phoneNumbers)) {
       throw new TypeError('phoneNumbers must be an array')
-    if (hasEmailAddresses && !Array.isArray(contact.emailAddresses))
+    }
+
+    if (hasEmailAddresses && !Array.isArray(contact.emailAddresses)) {
       throw new TypeError('emailAddresses must be an array')
+    }
 
     if (hasBirthday) {
       const datePattern = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/
@@ -52,16 +75,25 @@ function updateContact(contact) {
     const hasPhoneNumbers = contact.hasOwnProperty('phoneNumbers')
     const hasEmailAddresses = contact.hasOwnProperty('emailAddresses')
 
-    if (hasFirstName && typeof contact.firstName !== 'string')
+    if (hasFirstName && typeof contact.firstName !== 'string') {
       throw new TypeError('firstName must be a string')
-    if (hasLastName && typeof contact.lastName !== 'string')
+    }
+
+    if (hasLastName && typeof contact.lastName !== 'string') {
       throw new TypeError('lastName must be a string')
-    if (hasNickname && typeof contact.nickname !== 'string')
+    }
+
+    if (hasNickname && typeof contact.nickname !== 'string') {
       throw new TypeError('nickname must be a string')
-    if (hasPhoneNumbers && !Array.isArray(contact.phoneNumbers))
+    }
+
+    if (hasPhoneNumbers && !Array.isArray(contact.phoneNumbers)) {
       throw new TypeError('phoneNumbers must be an array')
-    if (hasEmailAddresses && !Array.isArray(contact.emailAddresses))
+    }
+
+    if (hasEmailAddresses && !Array.isArray(contact.emailAddresses)) {
       throw new TypeError('emailAddresses must be an array')
+    }
 
     if (hasBirthday) {
       const datePattern = /^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$/
@@ -77,14 +109,16 @@ function updateContact(contact) {
 }
 
 function deleteContact(name) {
-  if (typeof name !== 'string') throw new TypeError('name must be a string')
+  if (typeof name !== 'string') {
+    throw new TypeError('name must be a string')
+  }
 
   return contacts.deleteContact.call(this, name)
 }
 
 module.exports = {
   getAuthStatus: contacts.getAuthStatus,
-  getAllContacts: contacts.getAllContacts,
+  getAllContacts,
   getContactsByName,
   addNewContact,
   deleteContact,

--- a/test.js
+++ b/test.js
@@ -1,0 +1,8 @@
+const {
+  getContactsByName,
+  getAllContacts
+} = require('./index')
+
+const contacts = getAllContacts(['contactImage'])
+
+console.log(contacts[0])


### PR DESCRIPTION
Refs https://github.com/codebytere/node-mac-contacts/issues/5.

Adds the ability to request extra properties from contacts fetched via `getContactsByName()` or `getAllContacts()`.

So far, the following properties are optionally fetchable: `jobTitle`, `departmentName`, `organizationName`, `middleName`, `note`, `contactImage`, or `contactThumbnailImage`.

Usage is as follows:

```js
const { getAllContacts } = require('node-mac-contacts')

const contacts = getAllContacts(['contactImage'])

console.log(contacts[0])
// prints:
[
  { 
    firstName: 'Jonathan',
    lastName: 'Appleseed',
    nickname: 'Johnny',
    birthday: '1970-01-01',
    phoneNumbers: [ +11234566789' ],
    emailAddresses: [ 'johnny@appleseed.com' ],
    postalAddresses: [ '123 Pine Tree Way\nBlack Oak, Arkansas 72414\nUnited States' ],
    contactImage: <Buffer ff d8 ff e0 00 10 4a 46 49 46 00 01 01 00 00 48 00 48 00 00 ff e1 00 4c 45 78 69 66 00 00 4d 4d 00 2a 00 00 00 08 00 01 87 69 00 04 00 00 00 01 00 00 ... 139493 more bytes>
  }
]
```

`instantMessageAddresses` and `socialProfiles` will be added in a follow-up PR, as they require slightly more work and it's easier to split out that work.

cc @KishanBagaria 