### PR TITLE
feat: return identifier with contacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Returns `Array<Object>` - Returns an array of contact objects.
 
 The returned objects will take the following format:
 
+* `identifier` String - The contact's unique identifier.
 * `firstName` String - The contact's first name, or an empty string ('') if one is not set.
 * `lastName` String - The contact's last name, or an empty string ('') if one is not set.
 * `nickname` String - The contact's nickname, or an empty string ('') if one is not set.
@@ -106,6 +107,7 @@ If a contact's full name is 'Shelley Vohr', I could pass 'Shelley', 'Vohr', or '
 
 The returned object will take the following format:
 
+* `identifier` String - The contact's unique identifier.
 * `firstName` String - The contact's first name, or an empty string ('') if one is not set.
 * `lastName` String - The contact's last name, or an empty string ('') if one is not set.
 * `nickname` String - The contact's nickname, or an empty string ('') if one is not set.

--- a/contacts.mm
+++ b/contacts.mm
@@ -143,6 +143,8 @@ Napi::Object CreateContact(Napi::Env env, CNContact *cncontact) {
 
   // Default contact properties.
 
+  contact.Set("identifier", std::string([[cncontact identifier] UTF8String]));
+
   contact.Set("firstName", std::string([[cncontact givenName] UTF8String]));
   contact.Set("lastName", std::string([[cncontact familyName] UTF8String]));
   contact.Set("nickname", std::string([[cncontact nickname] UTF8String]));


### PR DESCRIPTION
Adds a new property to the returned Contact objects - the [identifier](https://developer.apple.com/documentation/contacts/cncontact/1403103-identifier?language=objc) string for the CNContact.