### PR TITLE
feat: allow deleting contacts by identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,14 @@ const success = contacts.addNewContact({
 console.log(`New contact was ${success ? 'saved' : 'not saved'}.`)
 ```
 
-### `contacts.deleteContact(name)`
+### `contacts.deleteContact({ identifier, name })`
 
-* `name` String (required) - The first, middle, last, or full name of a contact.
+* `identifier` String (optional) - The contact's unique identifier.
+* `name` String (optional) - The first, middle, last, or full name of a contact.
 
 Returns `Boolean` - whether the contact was deleted successfully.
 
-Deletes a contact to the user's contacts database.
+Deletes a contact from the user's contacts database.
 
 If a contact's full name is 'Shelley Vohr', I could pass 'Shelley', 'Vohr', or 'Shelley Vohr' as `name`.
 However, you should take care to specify `name` to such a degree that you can be confident the first contact to be returned from a predicate search is the contact you intend to delete.

--- a/index.js
+++ b/index.js
@@ -150,12 +150,23 @@ function updateContact(contact) {
   return contacts.updateContact.call(this, contact)
 }
 
-function deleteContact(name) {
-  if (typeof name !== 'string') {
+function deleteContact(contact) {
+  if (!contact || Object.keys(contact).length === 0) {
+    throw new TypeError('contact must be a non-empty object')
+  }
+
+  const hasIdentifier = contact.hasOwnProperty('identifier')
+  const hasName = contact.hasOwnProperty('name')
+
+  if (hasIdentifier && typeof contact.identifier !== 'string') {
+    throw new TypeError('identifier must be a string')
+  }
+
+  if (hasName && typeof contact.name !== 'string') {
     throw new TypeError('name must be a string')
   }
 
-  return contacts.deleteContact.call(this, name)
+  return contacts.deleteContact.call(this, contact)
 }
 
 module.exports = {

--- a/test/module.spec.js
+++ b/test/module.spec.js
@@ -150,11 +150,16 @@ describe('node-mac-contacts', () => {
     })
   })
 
-  describe('deleteContact(name)', () => {
+  describe('deleteContact({ name, identifier })', () => {
     it('should throw if name is not a string', () => {
       expect(() => {
-        deleteContact(12345)
+        deleteContact({ name: 12345 })
       }).to.throw(/name must be a string/)
+    })
+    it('should throw if identifier is not a string', () => {
+      expect(() => {
+        deleteContact({ identifier: 12345 })
+      }).to.throw(/identifier must be a string/)
     })
   })
 


### PR DESCRIPTION
This PR makes it possible to delete contacts by identifier which is less error prone than by predicate when you want to delete a single contact.

#8 