### PR TITLE
chore(deps): specify operating system

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,6 @@
     "*.mm": [
       "clang-format -i"
     ]
-  }
+  },
+  "os": ["darwin"]
 }


### PR DESCRIPTION
This makes sure yarn/npm stops early before trying to build and install on non-macOS platforms.

> The platform "linux" is incompatible with this module.
> The platform "win32" is incompatible with this module.